### PR TITLE
pep8, bug fix

### DIFF
--- a/configs/test_seasurfaceheight_config.yaml
+++ b/configs/test_seasurfaceheight_config.yaml
@@ -1,0 +1,20 @@
+nasa_earthdata_collections:
+  ids:
+    - 'SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205'
+
+# Must be a bounding box
+bounds:
+  -  [-76.6, 38.8, -76.5, 38.9]
+
+# Must be in YYYY-MM-DD
+time_bounds:
+  start: '2019-05-18'
+  end: '2019-06-18'
+
+title:
+  title: '# EIS General Dashboard'
+  subtitle: '## Alpha version: 0.3.0'
+
+# MUST BE 'INFO', 'WARN', 'DEBUG'
+log_level: 'INFO'
+log_dir: '.'

--- a/eisdashboard/model/dashboard.py
+++ b/eisdashboard/model/dashboard.py
@@ -32,7 +32,8 @@ class Dashboard(object):
 
     NCOLS: int = 2
 
-    BANNED_VARIABLES: list = ['lat', 'lon', 'time', 'time_bnds']
+    BANNED_VARIABLES: list = ['lat', 'lon', 'time', 'time_bnds',
+                              'time_bounds', 'lat_bounds', 'lon_bounds']
 
     # ------------------------------------------------------------------------
     # __init__
@@ -79,7 +80,7 @@ class Dashboard(object):
 
         self._validStarterVariables = [
             var for var in self._variableOptions
-            if self.parseVariableOption(var)[1] not
+            if self.parseVariableOption(var)[1].lower() not
             in self.BANNED_VARIABLES]
 
         self._logger.debug(self._validStarterVariables)

--- a/notebooks/eis-dashboard-raster.ipynb
+++ b/notebooks/eis-dashboard-raster.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dashboard = RasterDashboard(config_file='../../eis-dashboard/configs/dev_configs/example_config_raster.yaml')"
+    "dashboard = RasterDashboard(config_file='../../eis-dashboard/configs/test_seasurfaceheight_config.yaml')"
    ]
   },
   {

--- a/tests/test_Ingest.py
+++ b/tests/test_Ingest.py
@@ -132,7 +132,7 @@ class TestIngest(unittest.TestCase):
 
         self.assertTrue(list(result_dataset.coords.keys()) == expected_coords)
         self.assertTrue(list(result_dataset.dims.keys()) == expected_dims)
-        
+ 
     def test_refine_urls(self):
         ingest = Ingest(self.config)
 
@@ -156,7 +156,6 @@ class TestIngest(unittest.TestCase):
         expected_result_case3 = ()
         self.assertEqual(ingest._refine_urls(urls_case3),
                          expected_result_case3)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_Ingest.py
+++ b/tests/test_Ingest.py
@@ -132,7 +132,7 @@ class TestIngest(unittest.TestCase):
 
         self.assertTrue(list(result_dataset.coords.keys()) == expected_coords)
         self.assertTrue(list(result_dataset.dims.keys()) == expected_dims)
- 
+
     def test_refine_urls(self):
         ingest = Ingest(self.config)
 


### PR DESCRIPTION
Hotfix 0.3.1

Fixes #24

Purpose: User reported errors when trying to run the raster notebook with NASA earthdata `SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205`

Bug: A bug was found where if the dimensions/coords of the ingested data are case-sensitive Lat/Latitude, Time, etc the code will return a key-error.

Solution: Add a function which if there are upper case dim/coord names it will rename all coords and dims (and set indexes) to the lower-case name. 